### PR TITLE
plugin name is exercises, updating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use the exercises plugin in your Gitbook project, add the `exercises` plugin 
 
 ```
 {
-    "plugins": ["exercise"]
+    "plugins": ["exercises"]
 }
 ```
 > If you want to use multiple plugins in your project, seperate the plugin names with a comma.  For example: `"plugins": ["quizzes", "exercises"]`.


### PR DESCRIPTION
Plugin name is the plural, so should be exercises and not exercise.

Updating the README.md file to correct the plugin configuration example.
